### PR TITLE
feat: support retry and wait until a lock is released

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This action enables you to manage lock in GitHub Actions Workflows.
 
 ## How to use
 
-Example 1. Lock while running deploy.sh:
+### Example 1. Lock while running deploy.sh:
 
 ```yaml
 jobs:
@@ -37,8 +37,12 @@ jobs:
       - run: bash deploy.sh
 ```
 
+### `post_unlock` - Release a lock by post step
+
 By default, this action doesn't release a lock automatically even after the job has been completed.
 If you want to release a lock automatically after the job, you can use the input `post_unlock: "true"`.
+
+### `ignore_already_locked_error` - Ignore the failure even if the key has already been locked
 
 The action fails if the key has already been locked.
 If you want to continue jobs, you can ignore the failure using the input `ignore_already_locked_error`.
@@ -54,7 +58,7 @@ If you want to continue jobs, you can ignore the failure using the input `ignore
   if: steps.lock.outputs.already_locked == 'true' # Refer the result via outputs
 ```
 
-Example 2. Unlock
+### Example 2. Unlock
 
 ```yaml
 - uses: suzuki-shunsuke/lock-action@v0.1.1
@@ -63,7 +67,7 @@ Example 2. Unlock
     key: foo
 ```
 
-Example 3. Check if the key is being locked
+### Example 3. Check if the key is being locked
 
 ```yaml
 - uses: suzuki-shunsuke/lock-action@v0.1.1
@@ -74,6 +78,37 @@ Example 3. Check if the key is being locked
 - run: echo "already locked"
   if: steps.check.outputs.already_locked == 'true' # Refer the result via outputs
 ```
+
+### Wait until a lock is released
+
+You can wait until a lock is released using inputs `max_wait_seconds` and `wait_interval_seconds`.
+
+1. Check
+
+```yaml
+- uses: suzuki-shunsuke/lock-action@latest
+  id: check
+  with:
+    mode: check
+    key: default
+    max_wait_seconds: "60"
+    wait_interval_seconds: "10"
+```
+
+2. Lock
+
+```yaml
+- uses: suzuki-shunsuke/lock-action@pr/70
+  with:
+    mode: lock
+    key: default
+    max_wait_seconds: "60"
+    wait_interval_seconds: "10"
+```
+
+By default `max_wait_seconds` is 0, meaning this action doesn't wait.
+If the mode is `lock` and `max_wait_seconds` is greater than 0, this action retries to acquire the lock every `wait_interval_seconds` until `max_wait_seconds`.
+If the mode is `check` and `max_wait_seconds` is greater than 0, this action retries to check the lock every `wait_interval_seconds` until `max_wait_seconds`.
 
 ## Available versions
 

--- a/action.yaml
+++ b/action.yaml
@@ -56,6 +56,16 @@ inputs:
       If this is `true`, the action does not fail when it can't acquire the lock as the key is already being locked.
     default: "false"
     required: false
+  max_wait_seconds:
+    description: |
+      The maximum seconds to wait for the lock.
+    default: "0"
+    required: false
+  wait_interval_seconds:
+    description: |
+      Wait interval seconds to check or acquire the lock.
+    default: "30"
+    required: false
 outputs:
   already_locked:
     description: Whether the key is already locked

--- a/action.yaml
+++ b/action.yaml
@@ -58,12 +58,12 @@ inputs:
     required: false
   max_wait_seconds:
     description: |
-      The maximum seconds to wait for the lock.
+      The maximum seconds to wait until the lock is released.
     default: "0"
     required: false
   wait_interval_seconds:
     description: |
-      Wait interval seconds to check or acquire the lock.
+      The interval seconds to check or try to acquire the lock.
     default: "30"
     required: false
 outputs:

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -33,15 +33,16 @@ export const getMsg = (input: Input): string => {
 ${JSON.stringify(metadata, null, "  ")}`;
 };
 
-type Metadata = {
+export type Metadata = {
   message: string;
   state: string;
   actor: string;
   github_actions_workflow_run_url: string;
   pull_request_number?: number;
+  datetime?: string;
 };
 
-export const extractMetadata = (message: string, key: string): any => {
+export const extractMetadata = (message: string, key: string): Metadata => {
   const idx = message.indexOf("\n");
   if (idx === -1) {
     throw new Error(`The message of key ${key} is invalid`);

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -13,6 +13,8 @@ export type Input = {
   repo: string;
   message: string;
   ignoreAlreadyLockedError: boolean;
+  maxWaitSeconds: number;
+  waitIntervalSeconds: number;
 };
 
 export const getMsg = (input: Input): string => {

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -47,6 +47,9 @@ const _lock = async (input: lib.Input): Promise<any> => {
     if (result === Result.Locked) {
       return result;
     }
+    if (result === Result.AlreadyLocked && input.ignoreAlreadyLockedError) {
+      return result;
+    }
     if (now - startTime > input.maxWaitSeconds * 1000) {
       return result;
     }

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -1,7 +1,7 @@
 import * as core from "@actions/core";
 import * as github from "@actions/github";
 import * as lib from "./lib";
-import { setTimeout, setInterval } from "timers/promises";
+import { setInterval } from "timers/promises";
 
 enum Result {
   AlreadyLocked,

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -13,7 +13,6 @@ export const lock = async (input: lib.Input) => {
   let result = await _lock(input);
   switch (result) {
     case Result.AlreadyLocked:
-      core.info(`The key ${input.key} has already been locked`);
       core.setOutput("already_locked", true);
       if (input.ignoreAlreadyLockedError) {
         return;

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -16,7 +16,6 @@ export const lock = async (input: lib.Input) => {
       core.info(`The key ${input.key} has already been locked`);
       core.setOutput("already_locked", true);
       if (input.ignoreAlreadyLockedError) {
-        core.info(`The key ${input.key} has already been locked`);
         return;
       }
       throw new Error(`The key ${input.key} has already been locked`);

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -17,12 +17,16 @@ export const lock = async (input: lib.Input) => {
       if (input.ignoreAlreadyLockedError) {
         return;
       }
+      core.error(`The key ${input.key} has already been locked`);
       throw new Error(`The key ${input.key} has already been locked`);
     case Result.Locked:
       core.info(`The key ${input.key} has been locked`);
       core.saveState(`got_lock`, true);
       return;
     case Result.FailedToGetLock:
+      core.error(
+        `Failed to acquire lock. Probably the key ${input.key} has already been locked`,
+      );
       throw new Error(
         `Failed to acquire lock. Probably the key ${input.key} has already been locked`,
       );

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -18,13 +18,16 @@ export const lock = async (input: lib.Input): Promise<any> => {
     return result;
   }
   core.info(`The key ${input.key} has already been locked. Waiting...`);
-  for await (const startTime of setInterval(input.waitIntervalSeconds * 1000, Date.now())) {
+  for await (const startTime of setInterval(
+    input.waitIntervalSeconds * 1000,
+    Date.now(),
+  )) {
     const now = Date.now();
     result = await _lock(input);
     if (result === Result.Locked) {
       return result;
     }
-    if ((now - startTime) > input.maxWaitSeconds * 1000) {
+    if (now - startTime > input.maxWaitSeconds * 1000) {
       return result;
     }
     core.info(`The key ${input.key} has already been locked. Waiting...`);
@@ -56,9 +59,12 @@ const _lock = async (input: lib.Input): Promise<Result> => {
   switch (metadata.state) {
     case "lock":
       if (input.maxWaitSeconds !== 0) {
-        for await (const startTime of setInterval(input.waitIntervalSeconds * 1000, Date.now())) {
+        for await (const startTime of setInterval(
+          input.waitIntervalSeconds * 1000,
+          Date.now(),
+        )) {
           const now = Date.now();
-          if ((now - startTime) > input.maxWaitSeconds * 1000) {
+          if (now - startTime > input.maxWaitSeconds * 1000) {
             break;
           }
           core.info(`The key ${input.key} has already been locked. Waiting...`);

--- a/src/run.ts
+++ b/src/run.ts
@@ -21,6 +21,8 @@ export const main = async () => {
     ignoreAlreadyLockedError: core.getBooleanInput(
       "ignore_already_locked_error",
     ),
+    waitIntervalSeconds: parseInt(core.getInput("wait_interval_seconds"), 10),
+    maxWaitSeconds: parseInt(core.getInput("max_wait_seconds"), 10),
   });
 };
 


### PR DESCRIPTION
Close #18

This pull request adds inputs `max_wait_seconds` and `wait_interval_seconds`.
By default `max_wait_seconds` is 0 and this action doesn't retry.
Modes `lock` and `check` support these inputs.

If the mode is `lock` and `max_wait_seconds` is greater than 0, this action retries to acquire the lock every `wait_interval_seconds` until `max_wait_seconds`.

If the mode is `check` and `max_wait_seconds` is greater than 0, this action retries to check the lock every `wait_interval_seconds` until `max_wait_seconds`.

1. check

```yaml
- uses: suzuki-shunsuke/lock-action@pr/70
  id: check
  with:
    mode: check
    key: default
    max_wait_seconds: "60"
    wait_interval_seconds: "10"
```

2. lock

```yaml
- uses: suzuki-shunsuke/lock-action@pr/70
  with:
    mode: lock
    key: default
    max_wait_seconds: "60"
    wait_interval_seconds: "10"
```
