### PR TITLE
feat(check): add the option fail_if_locked

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ If you want to continue jobs, you can ignore the failure using the input `ignore
   if: steps.check.outputs.already_locked == 'true' # Refer the result via outputs
 ```
 
+### `fail_if_locked` - Fail if a key is being locked
+
+```yaml
+- uses: suzuki-shunsuke/lock-action@latest
+  with:
+    mode: check
+    key: foo
+    fail_if_locked: "true"
+```
+
 ### Wait until a lock is released
 
 You can wait until a lock is released using inputs `max_wait_seconds` and `wait_interval_seconds`.
@@ -87,10 +97,10 @@ You can wait until a lock is released using inputs `max_wait_seconds` and `wait_
 
 ```yaml
 - uses: suzuki-shunsuke/lock-action@latest
-  id: check
   with:
     mode: check
     key: default
+    fail_if_locked: "true"
     max_wait_seconds: "60"
     wait_interval_seconds: "10"
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -66,6 +66,11 @@ inputs:
       The interval seconds to check or try to acquire the lock.
     default: "30"
     required: false
+  fail_if_locked:
+    description: |
+      Fail if the key is already locked. This input is for `check` mode.
+    default: "false"
+    required: false
 outputs:
   already_locked:
     description: Whether the key is already locked

--- a/src/check.ts
+++ b/src/check.ts
@@ -23,6 +23,11 @@ export const check = async (input: lib.Input) => {
   core.setOutput("already_locked", alreadyLocked);
   core.info(`already_locked: ${alreadyLocked}`);
   if (alreadyLocked && input.failIfLocked) {
+    core.error(`The key ${input.key} has already been locked.
+actor: ${metadata.actor}
+datetime: ${metadata.datetime}
+workflow: ${metadata.github_actions_workflow_run_url}
+message: ${metadata.message}`);
     throw new Error(`The key ${input.key} has already been locked`);
   }
 };

--- a/src/check.ts
+++ b/src/check.ts
@@ -16,8 +16,15 @@ type Result = {
 
 export const check = async (input: lib.Input) => {
   const metadata = await _check(input);
-  core.setOutput("result", JSON.stringify(metadata));
-  core.setOutput("already_locked", metadata?.state === "lock");
+  const s = JSON.stringify(metadata ?? {});
+  core.setOutput("result", s);
+  core.info(`result: ${s}`);
+  const alreadyLocked = metadata?.state === "lock";
+  core.setOutput("already_locked", alreadyLocked);
+  core.info(`already_locked: ${alreadyLocked}`);
+  if (alreadyLocked && input.failIfLocked) {
+    throw new Error(`The key ${input.key} has already been locked`);
+  }
 };
 
 const _check = async (input: lib.Input): Promise<lib.Metadata | undefined> => {

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -15,6 +15,7 @@ export type Input = {
   ignoreAlreadyLockedError: boolean;
   maxWaitSeconds: number;
   waitIntervalSeconds: number;
+  failIfLocked: boolean;
 };
 
 export const getMsg = (input: Input): string => {

--- a/src/run.ts
+++ b/src/run.ts
@@ -8,8 +8,8 @@ import * as post from "./post";
 export const main = async () => {
   run({
     post: core.getState("post"),
-    mode: core.getInput("mode"),
-    key: core.getInput("key"),
+    mode: core.getInput("mode", { required: true }),
+    key: core.getInput("key", { required: true }),
     keyPrefix: core.getInput("key_prefix"),
     githubToken: core.getInput("github_token"),
     owner:
@@ -23,6 +23,7 @@ export const main = async () => {
     ),
     waitIntervalSeconds: parseInt(core.getInput("wait_interval_seconds"), 10),
     maxWaitSeconds: parseInt(core.getInput("max_wait_seconds"), 10),
+    failIfLocked: core.getBooleanInput("fail_if_locked"),
   });
 };
 


### PR DESCRIPTION
Close #54

This pull request adds an input `fail_if_locked`.
This input is for `mode: check`.

e.g.

```yaml
- uses: suzuki-shunsuke/lock-action@latest
  with:
    mode: check
    key: foo
    fail_if_locked: "true"
```