### PR TITLE
feat: add an output `locked`

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,31 +120,31 @@ These inputs are also available for `mode: check`.
 The output is useful if you want to release a lock in a later job.
 
 ```yaml
-  lock:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    outputs:
-      locked: ${{steps.lock.outputs.locked}}
-    steps:
-      - uses: suzuki-shunsuke/lock-action@c752be910ac812e0adc50316855416514d364b57 # v0.1.3
-        id: lock
-        with:
-          mode: lock
-          key: dev
-      # ...
+lock:
+  runs-on: ubuntu-latest
+  permissions:
+    contents: write
+  outputs:
+    locked: ${{steps.lock.outputs.locked}}
+  steps:
+    - uses: suzuki-shunsuke/lock-action@c752be910ac812e0adc50316855416514d364b57 # v0.1.3
+      id: lock
+      with:
+        mode: lock
+        key: dev
+    # ...
 
-  unlock:
-    runs-on: ubuntu-latest
-    needs: lock
-    permissions:
-      contents: write
-    steps:
-      - uses: suzuki-shunsuke/lock-action@c752be910ac812e0adc50316855416514d364b57 # v0.1.3
-        if: needs.lock.outputs.locked == 'true'
-        with:
-          mode: unlock
-          key: dev
+unlock:
+  runs-on: ubuntu-latest
+  needs: lock
+  permissions:
+    contents: write
+  steps:
+    - uses: suzuki-shunsuke/lock-action@c752be910ac812e0adc50316855416514d364b57 # v0.1.3
+      if: needs.lock.outputs.locked == 'true'
+      with:
+        mode: unlock
+        key: dev
 ```
 
 ## Available versions

--- a/README.md
+++ b/README.md
@@ -116,6 +116,37 @@ These inputs are also available for `mode: check`.
     wait_interval_seconds: "5"
 ```
 
+[#131](https://github.com/suzuki-shunsuke/lock-action/issues/131) [#135](https://github.com/suzuki-shunsuke/lock-action/pull/135) [>= v0.1.4](https://github.com/suzuki-shunsuke/lock-action/releases/tag/v0.1.4) You can check if this action can acquire the lock in later jobs using the output `locked`.
+The output is useful if you want to release a lock in a later job.
+
+```yaml
+  lock:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      locked: ${{steps.lock.outputs.locked}}
+    steps:
+      - uses: suzuki-shunsuke/lock-action@c752be910ac812e0adc50316855416514d364b57 # v0.1.3
+        id: lock
+        with:
+          mode: lock
+          key: dev
+      # ...
+
+  unlock:
+    runs-on: ubuntu-latest
+    needs: lock
+    permissions:
+      contents: write
+    steps:
+      - uses: suzuki-shunsuke/lock-action@c752be910ac812e0adc50316855416514d364b57 # v0.1.3
+        if: needs.lock.outputs.locked == 'true'
+        with:
+          mode: unlock
+          key: dev
+```
+
 ## Available versions
 
 > [!CAUTION]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ steps:
       mode: check
       key: foo
   - run: bash deploy.sh foo
-    if: steps.check.outputs.already_locked != 'true'
+    if: steps.check.outputs.locked != 'true'
 ```
 
 You can also use `post_unlock: "true"` to release a lock automatically in a post step.

--- a/action.yaml
+++ b/action.yaml
@@ -72,8 +72,12 @@ inputs:
     default: "false"
     required: false
 outputs:
+  locked:
+    description: Whether the key is locked 
   already_locked:
-    description: Whether the key is already locked
+    description: |
+      Whether the key is already locked.
+      The difference between `already_locked` is that if `mode` is `lock` and the lock has already been acquired, `already_locked` is `true` and `locked` is `false`.
   result:
     description: The lock result
 runs:

--- a/action.yaml
+++ b/action.yaml
@@ -77,7 +77,9 @@ outputs:
   already_locked:
     description: |
       Whether the key is already locked.
-      The difference between `already_locked` is that if `mode` is `lock` and the lock has already been acquired, `already_locked` is `true` and `locked` is `false`.
+      The difference between `already_locked` is that if `mode` is `lock` and the lock has already been acquired, `already_locked` is `true` but `locked` is `false`.
+      And if the lock hasn't been acquired and the action can acquire a lock, `already_locked` is `false` but `locked` is `true`.
+      If `mode` is `check`, there is no difference between `already_locked` and `locked`.
   result:
     description: The lock result
 runs:

--- a/action.yaml
+++ b/action.yaml
@@ -73,7 +73,7 @@ inputs:
     required: false
 outputs:
   locked:
-    description: Whether the key is locked 
+    description: Whether the key is locked
   already_locked:
     description: |
       Whether the key is already locked.

--- a/src/check.ts
+++ b/src/check.ts
@@ -20,6 +20,7 @@ export const check = async (input: lib.Input) => {
   core.setOutput("result", s);
   core.info(`result: ${s}`);
   const alreadyLocked = metadata?.state === "lock";
+  core.setOutput("locked", alreadyLocked);
   core.setOutput("already_locked", alreadyLocked);
   core.info(`already_locked: ${alreadyLocked}`);
   if (alreadyLocked && input.failIfLocked) {

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -14,6 +14,7 @@ export const lock = async (input: lib.Input) => {
   switch (result) {
     case Result.AlreadyLocked:
       core.setOutput("already_locked", true);
+      core.setOutput("locked", true);
       if (input.ignoreAlreadyLockedError) {
         return;
       }
@@ -21,9 +22,12 @@ export const lock = async (input: lib.Input) => {
       throw new Error(`The key ${input.key} has already been locked`);
     case Result.Locked:
       core.info(`The key ${input.key} has been locked`);
+      core.setOutput("already_locked", false);
+      core.setOutput("locked", true);
       core.saveState(`got_lock`, true);
       return;
     case Result.FailedToGetLock:
+      core.setOutput("locked", false);
       core.error(
         `Failed to acquire lock. Probably the key ${input.key} has already been locked`,
       );

--- a/src/lock.ts
+++ b/src/lock.ts
@@ -14,7 +14,7 @@ export const lock = async (input: lib.Input) => {
   switch (result) {
     case Result.AlreadyLocked:
       core.setOutput("already_locked", true);
-      core.setOutput("locked", true);
+      core.setOutput("locked", false);
       if (input.ignoreAlreadyLockedError) {
         return;
       }


### PR DESCRIPTION
- https://github.com/suzuki-shunsuke/lock-action/issues/131

Add an output `locked` if `mode` is either `lock` or `check`.
This output is useful for other GitHub Actions jobs to check if the job acquires the lock.

e.g.

```yaml
  lock:
    runs-on: ubuntu-latest
    permissions:
      contents: write
    outputs:
      locked: ${{steps.lock.outputs.locked}}
    steps:
      - uses: suzuki-shunsuke/lock-action@c752be910ac812e0adc50316855416514d364b57 # v0.1.3
        id: lock
        with:
          mode: lock
          key: dev
      # ...

  unlock:
    runs-on: ubuntu-latest
    needs: lock
    permissions:
      contents: write
    steps:
      - uses: suzuki-shunsuke/lock-action@c752be910ac812e0adc50316855416514d364b57 # v0.1.3
        if: needs.lock.outputs.locked == 'true'
        with:
          mode: unlock
          key: dev
```