### PR TITLE
feat: support deleting branches when releasing locks

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,17 @@ unlock:
 ```
 
 By default, this action adds a unlock history to a key when releasing a lock.
-By setting `history: "none"`, this action removes a key when releasing a lock.
+By setting `remove_key_when_unlock: "true"`, this action removes a key when releasing a lock.
 This allows you to acquire the list of locked keys easily and keep keys clean.
 If you need only the latest lock histories, you may prefer this option.
+
+```yaml
+- uses: suzuki-shunsuke/lock-action@latest
+  with:
+    mode: unlock
+    key: dev
+    remove_key_when_unlock: "true"
+```
 
 ## Available versions
 
@@ -230,7 +238,7 @@ Example links:
 - [Commit history for a specific lock](https://github.com/suzuki-shunsuke/lock-action/commits/lock__test-1/)
 
 When releasing a lock, this action adds a commit to a branch by default.
-If you set `history: "none"`, this action removes a branch when releasing a lock.
+If you set `remove_key_when_unlock: "true"`, this action removes a branch when releasing a lock.
 
 ## Inputs / Outputs
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ unlock:
         key: dev
 ```
 
+By default, this action adds a unlock history to a key when releasing a lock.
+By setting `history: "none"`, this action removes a key when releasing a lock.
+This allows you to acquire the list of locked keys easily and keep keys clean.
+If you need only the latest lock histories, you may prefer this option.
+
 ## Available versions
 
 > [!CAUTION]
@@ -223,6 +228,9 @@ Example links:
 
 - [Branch list](https://github.com/suzuki-shunsuke/lock-action/branches/all?query=lock__&lastTab=overview)
 - [Commit history for a specific lock](https://github.com/suzuki-shunsuke/lock-action/commits/lock__test-1/)
+
+When releasing a lock, this action adds a commit to a branch by default.
+If you set `history: "none"`, this action removes a branch when releasing a lock.
 
 ## Inputs / Outputs
 

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,12 @@ inputs:
     required: true
 
   # Optional
+  history:
+    description: |
+      If this is "keep", all histories are stored to branches.
+      If this is "none", branches are deleted when releasing the lock.
+    required: false
+    default: "keep"
   key_prefix:
     description: |
       A lock key prefix.

--- a/action.yaml
+++ b/action.yaml
@@ -19,12 +19,13 @@ inputs:
     required: true
 
   # Optional
-  history:
+  remove_key_when_unlock:
     description: |
-      If this is "keep", all histories are stored to branches.
-      If this is "none", branches are deleted when releasing the lock.
+      Either "true" or "false".
+      If this is "true", the key is removed when releasing the lock.
+      If this is "false", all histories are kept.
     required: false
-    default: "keep"
+    default: "false"
   key_prefix:
     description: |
       A lock key prefix.

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -6,7 +6,7 @@ export const rootTree = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"; // https://s
 export type Input = {
   post: string;
   mode: string;
-  history: string;
+  removeKeyWhenUnlock: boolean;
   key: string;
   keyPrefix: string;
   githubToken: string;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -6,6 +6,7 @@ export const rootTree = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"; // https://s
 export type Input = {
   post: string;
   mode: string;
+  historyMode: string;
   key: string;
   keyPrefix: string;
   githubToken: string;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -6,7 +6,7 @@ export const rootTree = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"; // https://s
 export type Input = {
   post: string;
   mode: string;
-  historyMode: string;
+  history: string;
   key: string;
   keyPrefix: string;
   githubToken: string;

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,7 +9,7 @@ export const main = async () => {
   run({
     post: core.getState("post"),
     mode: core.getInput("mode", { required: true }),
-    historyMode: core.getInput("history_mode"),
+    history: core.getInput("history"),
     key: core.getInput("key", { required: true }),
     keyPrefix: core.getInput("key_prefix"),
     githubToken: core.getInput("github_token"),

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,7 +9,7 @@ export const main = async () => {
   run({
     post: core.getState("post"),
     mode: core.getInput("mode", { required: true }),
-    historyMode: core.getInput("history_mode", { required: true }),
+    historyMode: core.getInput("history_mode"),
     key: core.getInput("key", { required: true }),
     keyPrefix: core.getInput("key_prefix"),
     githubToken: core.getInput("github_token"),

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,6 +9,7 @@ export const main = async () => {
   run({
     post: core.getState("post"),
     mode: core.getInput("mode", { required: true }),
+    historyMode: core.getInput("history_mode", { required: true }),
     key: core.getInput("key", { required: true }),
     keyPrefix: core.getInput("key_prefix"),
     githubToken: core.getInput("github_token"),

--- a/src/run.ts
+++ b/src/run.ts
@@ -9,7 +9,7 @@ export const main = async () => {
   run({
     post: core.getState("post"),
     mode: core.getInput("mode", { required: true }),
-    history: core.getInput("history"),
+    removeKeyWhenUnlock: core.getBooleanInput("remove_key_when_unlock"),
     key: core.getInput("key", { required: true }),
     keyPrefix: core.getInput("key_prefix"),
     githubToken: core.getInput("github_token"),

--- a/src/unlock.ts
+++ b/src/unlock.ts
@@ -6,8 +6,13 @@ export const unlock = async (input: lib.Input): Promise<any> => {
   if (input.history === "none") {
     try {
       // Remove the branch
-      return removeKey(input);
+      await removeKey(input);
+      core.info(`The key ${input.key} has been removed`);
+      return;
     } catch (error: any) {
+      if (!error.message.includes("Reference does not exist")) {
+        throw error;
+      }
       // https://github.com/octokit/rest.js/issues/266
       core.error(`failed to remove a key ${input.key}: ${error.message}`);
       throw error;

--- a/src/unlock.ts
+++ b/src/unlock.ts
@@ -3,10 +3,10 @@ import * as github from "@actions/github";
 import * as lib from "./lib";
 
 export const unlock = async (input: lib.Input): Promise<any> => {
-  if (input.historyMode === "none") {
+  if (input.history === "none") {
     try {
       // Remove the branch
-      await removeKey(input);
+      return removeKey(input);
     } catch (error: any) {
       // https://github.com/octokit/rest.js/issues/266
       core.error(`failed to remove a key ${input.key}: ${error.message}`);

--- a/src/unlock.ts
+++ b/src/unlock.ts
@@ -6,12 +6,10 @@ export const unlock = async (input: lib.Input): Promise<any> => {
   if (input.history === "none") {
     try {
       // Remove the branch
-      await removeKey(input);
-      core.info(`The key ${input.key} has been removed`);
-      return;
+      return await removeKey(input);
     } catch (error: any) {
-      if (!error.message.includes("Reference does not exist")) {
-        throw error;
+      if (error.message.includes("Reference does not exist")) {
+        return;
       }
       // https://github.com/octokit/rest.js/issues/266
       core.error(`failed to remove a key ${input.key}: ${error.message}`);

--- a/src/unlock.ts
+++ b/src/unlock.ts
@@ -3,7 +3,7 @@ import * as github from "@actions/github";
 import * as lib from "./lib";
 
 export const unlock = async (input: lib.Input): Promise<any> => {
-  if (input.history === "none") {
+  if (input.removeKeyWhenUnlock) {
     try {
       // Remove the branch
       await removeKey(input);

--- a/src/unlock.ts
+++ b/src/unlock.ts
@@ -6,10 +6,12 @@ export const unlock = async (input: lib.Input): Promise<any> => {
   if (input.history === "none") {
     try {
       // Remove the branch
-      return await removeKey(input);
+      await removeKey(input);
+      core.info(`The key ${input.key} has been removed`);
+      return;
     } catch (error: any) {
-      core.info(error.message);
       if (error.message.includes("Reference does not exist")) {
+        core.info(`The key ${input.key} doesn't exist`);
         return;
       }
       // https://github.com/octokit/rest.js/issues/266

--- a/src/unlock.ts
+++ b/src/unlock.ts
@@ -8,6 +8,7 @@ export const unlock = async (input: lib.Input): Promise<any> => {
       // Remove the branch
       return await removeKey(input);
     } catch (error: any) {
+      core.info(error.message);
       if (error.message.includes("Reference does not exist")) {
         return;
       }
@@ -115,7 +116,7 @@ const removeKey = async (input: lib.Input): Promise<any> => {
   const branch = `${input.keyPrefix}${input.key}`;
   const ref = `heads/${branch}`;
   const octokit = github.getOctokit(input.githubToken);
-  octokit.rest.git.deleteRef({
+  return await octokit.rest.git.deleteRef({
     owner: input.owner,
     repo: input.repo,
     ref,


### PR DESCRIPTION
Close #215

The input `remove_key_when_unlock` is added.

```yaml
-   uses: suzuki-shunsuke/lock-action@latest
    with:
      mode: unlock
      key: foo
      remove_key_when_unlock: "true" # New
```

The value is either `true` or `false` (default).
The default behaviour isn't changed.
If the value is true, the action removes a branch when releasing a lock.