### PR TITLE
ci: verify the build on every pull request

### DIFF
--- a/.github/workflows/wc-build.yaml
+++ b/.github/workflows/wc-build.yaml
@@ -1,0 +1,23 @@
+---
+name: build
+on: workflow_call
+
+jobs:
+  build:
+    # Verify the action builds. create-pr-branch also builds, but it is gated on
+    # the pull request author because it needs write permissions to publish, so
+    # Renovate pull requests never exercise the build. This job has no
+    # permissions and runs for every pull request.
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .node-version
+          cache: npm
+      - run: npm ci
+      - run: npm run build

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -39,6 +39,10 @@ jobs:
     uses: ./.github/workflows/wc-ghalint.yaml
     permissions: {}
 
+  build:
+    uses: ./.github/workflows/wc-build.yaml
+    permissions: {}
+
   create-pr-branch:
     uses: ./.github/workflows/wc-create-pr-branch.yaml
     if: github.event.pull_request.user.login == 'suzuki-shunsuke'


### PR DESCRIPTION
Dependency updates are never built in this repository, so a bump that breaks the build merges unnoticed.

`create-pr-branch` runs `npm ci && npm run build`, but the whole job is gated on the pull request author:

```yaml
  create-pr-branch:
    uses: ./.github/workflows/wc-create-pr-branch.yaml
    if: github.event.pull_request.user.login == 'suzuki-shunsuke'
```

The gate is reasonable — that job also publishes a PR branch release and needs `contents: write` and `pull-requests: write`. But it means Renovate pull requests skip it, and Renovate is what bumps the toolchain.

This is not hypothetical. In suzuki-shunsuke/monitor-gh-follower-action, typescript v7 and `@vercel/ncc` 0.45.0 both merged with `test / create-pr-branch` reported as `SKIPPED`, and together they broke `npm run build` on `main` for a month before anyone noticed. Three more repositories were found in the same state.

## This change

Adds a `build` job with `permissions: {}` that checks out, installs and builds, and runs for every pull request regardless of author. Nothing in it needs write access, so the reason for the existing gate does not apply.

`status-check` already aggregates `needs.*.result` from the `test` workflow, so a build failure now blocks the merge instead of being invisible.

`create-pr-branch` is unchanged — it still builds before publishing, which is correct for the release path.

`npm run build` passes on the default branch of this repository today, so this should be green on arrival.

`actionlint` and `ghalint` both pass.

Same change as suzuki-shunsuke/monitor-gh-follower-action#715.
